### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bashcolor/__init__.py
+++ b/bashcolor/__init__.py
@@ -61,9 +61,9 @@ def colorize(
         start.append(effect)
         end.append(effect + _RESET_EFFECT)
 
-    start_code = "%s[%sm" % (_ESC, ';'.join([str(s) for s in start])) if text != '' else ''
-    end_code = "%s[%sm" % (_ESC, ';'.join([str(e) for e in end])) if with_end else ''
-    return "%s%s%s" % (start_code, text, end_code)
+    start_code = "{0!s}[{1!s}m".format(_ESC, ';'.join([str(s) for s in start])) if text != '' else ''
+    end_code = "{0!s}[{1!s}m".format(_ESC, ';'.join([str(e) for e in end])) if with_end else ''
+    return "{0!s}{1!s}{2!s}".format(start_code, text, end_code)
 
 
 def print_colors():
@@ -79,7 +79,7 @@ def print_colors():
         for c in ct:
             cs = str(c)
             padding = ''.join([' ' for e in range(3 - len(cs))])
-            text += colorize(' %s%s ' % (padding, cs), background_256=c, with_end=False)
+            text += colorize(' {0!s}{1!s} '.format(padding, cs), background_256=c, with_end=False)
         print(text + colorize('', background=DEFAULT))
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:bashcolor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:bashcolor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)